### PR TITLE
모듈 중복 Gradle 제거

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -54,10 +54,6 @@ dependencies {
     implementation implementation(project(':domain',))
     implementation(project(":presentation"))
     implementation 'androidx.core:core-ktx:1.7.0'
-
-    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.3.1'
-    implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.3.1'
-
     // timber
     implementation 'com.jakewharton.timber:timber:5.0.1'
 
@@ -72,20 +68,10 @@ dependencies {
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
 
-
-    implementation 'androidx.compose.material3:material3'
-    implementation "androidx.compose.material3:material3:1.1.1"
-
-    androidTestImplementation "androidx.compose.ui:ui-test-junit4:$compose_ui_version"
-    debugImplementation "androidx.compose.ui:ui-tooling:$compose_ui_version"
-    debugImplementation "androidx.compose.ui:ui-test-manifest:$compose_ui_version"
-
     //hilt
     implementation "com.google.dagger:hilt-android:2.44"
     kapt "com.google.dagger:hilt-compiler:2.44"
 
-    implementation "androidx.navigation:navigation-compose:2.5.3"
-    implementation "androidx.constraintlayout:constraintlayout-compose:1.0.1"
 
 }
 

--- a/presentation/src/main/java/com/kusitms/presentation/navigation/NavGraph.kt
+++ b/presentation/src/main/java/com/kusitms/presentation/navigation/NavGraph.kt
@@ -6,6 +6,7 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import com.kusitms.presentation.ui.login.LoginScreen
+import com.kusitms.presentation.ui.login.member.SignInScreen
 import com.kusitms.presentation.ui.splash.SplashScreen
 
 
@@ -24,6 +25,7 @@ fun KusitmsNavigation() {
         }
 
         composable(NavRoutes.SignInScreen.route) {
+            SignInScreen()
         }
 
         composable(NavRoutes.LogInScreen.route) {

--- a/presentation/src/main/java/com/kusitms/presentation/ui/signIn/SignInScreen.kt
+++ b/presentation/src/main/java/com/kusitms/presentation/ui/signIn/SignInScreen.kt
@@ -4,12 +4,17 @@ package com.kusitms.presentation.ui.login.member
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material.icons.filled.Menu
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavHostController
@@ -20,6 +25,56 @@ import com.kusitms.presentation.common.ui.theme.KusitmsTypo
 import com.kusitms.presentation.ui.ImageVector.StudyIcon
 import com.kusitms.presentation.ui.signIn.ButtonRow
 
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SignInScreen() {
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = {
+                    Text(
+                        "Simple TopAppBar",
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                },
+                navigationIcon = {
+                    IconButton(onClick = { /* doSomething() */ }) {
+                        Icon(
+                            imageVector = Icons.Filled.Menu,
+                            contentDescription = "Localized description"
+                        )
+                    }
+                },
+                actions = {
+                    IconButton(onClick = { /* doSomething() */ }) {
+                        Icon(
+                            imageVector = Icons.Filled.Favorite,
+                            contentDescription = "Localized description"
+                        )
+                    }
+                }
+            )
+        },
+        content = { innerPadding ->
+            LazyColumn(
+                contentPadding = innerPadding,
+                verticalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                val list = (0..75).map { it.toString() }
+                items(count = list.size) {
+                    Text(
+                        text = list[it],
+                        style = MaterialTheme.typography.bodyLarge,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 16.dp)
+                    )
+                }
+            }
+        }
+    )
+}
 
 @Composable
 fun SignInMember1(


### PR DESCRIPTION
**Chore: app모듈 gradle 중복 제거**
----------------------------------------
**Remain Gradles**
1. Timber
2. 기본 app 모듈
3. compose(compiler에 필)
4. hilt
-------------------------------------------
**module 수정 결과**
![image](https://github.com/Mnseo/Kusitms_android/assets/100370200/7241bf2f-2f73-4119-a86f-3f56371f8ba7)

Build 시간 단축 (**86%** 개선)
2m 51sec -> 24sec

