### PR TITLE
[큐시즘 둘러보기] 비회원 플로우 스크린 페이지 이동 확인 및 compose 완료

### DIFF
--- a/.idea/deploymentTargetDropDown.xml
+++ b/.idea/deploymentTargetDropDown.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="deploymentTargetDropDown">
+    <targetSelectedWithDropDown>
+      <Target>
+        <type value="QUICK_BOOT_TARGET" />
+        <deviceKey>
+          <Key>
+            <type value="VIRTUAL_DEVICE_PATH" />
+            <value value="C:\Users\USER\.android\avd\Resizable_Experimental_API_UpsideDownCake.avd" />
+          </Key>
+        </deviceKey>
+      </Target>
+    </targetSelectedWithDropDown>
+    <timeTargetWasSelectedWithDropDown value="2023-11-06T07:45:46.003340100Z" />
+  </component>
+</project>

--- a/presentation/src/main/java/com/kusitms/presentation/model/login/nonmember/Channel.kt
+++ b/presentation/src/main/java/com/kusitms/presentation/model/login/nonmember/Channel.kt
@@ -4,7 +4,8 @@ import androidx.compose.runtime.Composable
 
 data class Channel(
     val imageRes:Int,
-    val stringRes: Int
+    val stringRes: Int,
+    val uri: String
     )
 
 

--- a/presentation/src/main/java/com/kusitms/presentation/model/login/nonmember/Channels.kt
+++ b/presentation/src/main/java/com/kusitms/presentation/model/login/nonmember/Channels.kt
@@ -5,6 +5,8 @@ import com.kusitms.presentation.R
 
 object Channels {
     val channels = listOf(
-        Channel(R.drawable.ic_nonmember_insta, stringResource(id =R.string.nonMember_banner1))
+        Channel(R.drawable.ic_nonmember_insta, R.string.nonMember_banner1, "https://www.instagram.com/kusitms_official/"),
+        Channel(R.drawable.ic_nonmember_youtube, R.string.nonMember_banner2, "https://www.youtube.com/@KUSITMS"),
+        Channel(R.drawable.ic_nonmember_chat, R.string.nonMember_banner3, "https://cafe.naver.com/kusitms")
     )
 }

--- a/presentation/src/main/java/com/kusitms/presentation/ui/login/nonMember/NonMemberBanner.kt
+++ b/presentation/src/main/java/com/kusitms/presentation/ui/login/nonMember/NonMemberBanner.kt
@@ -1,10 +1,9 @@
 package com.kusitms.presentation.ui.login.nonMember
 
-import android.graphics.drawable.Icon
 import androidx.annotation.DrawableRes
-import androidx.annotation.IntegerRes
 import androidx.annotation.StringRes
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Text
@@ -12,8 +11,8 @@ import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.scale
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -22,6 +21,7 @@ import com.kusitms.presentation.R
 import com.kusitms.presentation.common.ui.theme.KusitmsColorPalette
 import com.kusitms.presentation.common.ui.theme.KusitmsTypo
 import com.kusitms.presentation.model.login.nonmember.Channel
+import com.kusitms.presentation.model.login.nonmember.Channels.channels
 
 @Composable
 fun NonMemberBanner() {
@@ -31,7 +31,7 @@ fun NonMemberBanner() {
         horizontalAlignment = Alignment.Start,
         verticalArrangement = Arrangement.Top
     ) {
-        InstaYoutubeRow()
+        InstaYoutubeRow(channels)
         Spacer(modifier = Modifier.height(12.dp))
         KusitmsNaverCafe()
     }
@@ -46,29 +46,32 @@ fun InstaYoutubeRow(channels: List<Channel>) {
         horizontalArrangement = Arrangement.spacedBy(8.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
-        channels.forEach { channel ->
+        channels.take(2).forEach { channel ->
             channelItem(
                 imageResId = channel.imageRes,
                 stringRes = channel.stringRes,
-                modifier = Modifier.weight(1f) // 여기에 weight를 추가합니다.
+                modifier = Modifier.weight(1f),
+                uri = channel.uri// 여기에 weight를 추가합니다.
             )
         }
     }
 }
 
 @Composable
-fun channelItem(@DrawableRes imageResId:Int, @StringRes stringRes:Int, modifier: Modifier) {
+fun channelItem(@DrawableRes imageResId:Int, @StringRes stringRes:Int, modifier: Modifier, uri:String) {
+    val uriHandler = LocalUriHandler.current
     Box(modifier = modifier
         .height(60.dp)
         .background(
             color = KusitmsColorPalette.current.Grey600,
             shape = RoundedCornerShape(size = 16.dp)
         )
+        .clickable { uriHandler.openUri(uri) }
     ) {
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .fillMaxHeight()
+                .height(60.dp)
                 .padding(horizontal = 20.dp),
             horizontalArrangement = Arrangement.spacedBy(8.dp),
             verticalAlignment = Alignment.CenterVertically
@@ -91,12 +94,16 @@ fun channelItem(@DrawableRes imageResId:Int, @StringRes stringRes:Int, modifier:
 
 @Composable
 fun KusitmsNaverCafe() {
+    val uriHandler = LocalUriHandler.current
     Box(modifier = Modifier
         .height(80.dp)
         .background(
             color = KusitmsColorPalette.current.Grey600,
             shape = RoundedCornerShape(size = 16.dp)
         )
+        .clickable {
+            uriHandler.openUri("https://cafe.naver.com/kusitms")
+        }
     ) {
         Row(
             modifier = Modifier

--- a/presentation/src/main/java/com/kusitms/presentation/ui/login/nonMember/NonMemberBanner.kt
+++ b/presentation/src/main/java/com/kusitms/presentation/ui/login/nonMember/NonMemberBanner.kt
@@ -51,7 +51,7 @@ fun InstaYoutubeRow(channels: List<Channel>) {
                 imageResId = channel.imageRes,
                 stringRes = channel.stringRes,
                 modifier = Modifier.weight(1f),
-                uri = channel.uri// 여기에 weight를 추가합니다.
+                uri = channel.uri
             )
         }
     }

--- a/presentation/src/main/java/com/kusitms/presentation/ui/login/nonMember/NonMemberPage.kt
+++ b/presentation/src/main/java/com/kusitms/presentation/ui/login/nonMember/NonMemberPage.kt
@@ -3,6 +3,7 @@ package com.kusitms.presentation.ui.login.nonMember
 import android.graphics.drawable.Icon
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Text
@@ -13,6 +14,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role.Companion.Image
@@ -21,14 +23,18 @@ import androidx.compose.ui.unit.dp
 import com.kusitms.presentation.R
 import com.kusitms.presentation.common.ui.theme.KusitmsColorPalette
 import com.kusitms.presentation.common.ui.theme.KusitmsTypo
+import com.kusitms.presentation.model.login.nonmember.Channels
 
 @Composable
 fun NonMemberPage() {
+    val uriHandler = LocalUriHandler.current
     Box(modifier = Modifier
         .fillMaxWidth()
         .height(160.dp)
         .background(color = KusitmsColorPalette.current.Main500, shape = RoundedCornerShape(16.dp))
-    ) {
+        .clickable { uriHandler.openUri("https://www.kusitms.com/") }
+    )
+    {
     Image(
         painter = painterResource(id = R.drawable.kusitms_non_member_1),
         contentDescription = null,
@@ -89,7 +95,7 @@ fun NonBottomPageRow() {
             style = KusitmsTypo.current.Body1,
             color = KusitmsColorPalette.current.Main200,
             modifier = Modifier
-                .width(168.dp)
+                .width(175.dp)
                 .height(48.dp)
         )
 

--- a/presentation/src/main/java/com/kusitms/presentation/ui/login/nonMember/NonMemberPage.kt
+++ b/presentation/src/main/java/com/kusitms/presentation/ui/login/nonMember/NonMemberPage.kt
@@ -38,8 +38,8 @@ fun NonMemberPage() {
     Image(
         painter = painterResource(id = R.drawable.kusitms_non_member_1),
         contentDescription = null,
-        contentScale = ContentScale.Crop, // 이미지가 Box를 채우도록 조정
-        modifier = Modifier.matchParentSize() // 부모의 크기에 맞춤
+        contentScale = ContentScale.Crop,
+        modifier = Modifier.matchParentSize()
     )
         Column(modifier = Modifier
             .fillMaxWidth()

--- a/presentation/src/main/java/com/kusitms/presentation/ui/login/nonMember/NonMemberScreen.kt
+++ b/presentation/src/main/java/com/kusitms/presentation/ui/login/nonMember/NonMemberScreen.kt
@@ -12,14 +12,11 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.kusitms.presentation.R
 import androidx.compose.material.Text
-import androidx.compose.material3.Icon
-import androidx.compose.ui.res.painterResource
 import androidx.navigation.NavController
 import androidx.navigation.compose.rememberNavController
 import com.kusitms.presentation.common.theme.KusitmsScaffoldNonScroll
 import com.kusitms.presentation.common.ui.theme.KusitmsColorPalette
 import com.kusitms.presentation.common.ui.theme.KusitmsTypo
-import com.kusitms.presentation.ui.login.member.LoginMemberColumn2
 import com.kusitms.presentation.ui.login.nonMember.NonMemberBanner
 import com.kusitms.presentation.ui.login.nonMember.NonMemberLogo
 import com.kusitms.presentation.ui.login.nonMember.NonMemberPage
@@ -48,8 +45,7 @@ fun NonMemberColumn() {
         Spacer(modifier = Modifier.height(95.5.dp))
         NonMemberLogoColumn()
         Spacer(modifier = Modifier.weight(1f))
-        NonMemberBanner()
-        Spacer(modifier = Modifier.height(61.dp))
+        NonMemberColumn2()
     }
 }
 
@@ -57,7 +53,7 @@ fun NonMemberColumn() {
 fun NonMemberLogoColumn() {
     Column(modifier = Modifier
         .fillMaxWidth()
-        .height(420.dp)
+        .height(140.dp)
         .background(color = KusitmsColorPalette.current.Grey800),
         horizontalAlignment =  Alignment.Start,
         verticalArrangement = Arrangement.Top
@@ -89,8 +85,22 @@ fun NonMemberLogoColumn() {
             )
         }
 
-        Spacer(modifier = Modifier.height(84.dp))
+    }
+}
+
+@Composable
+fun NonMemberColumn2() {
+    Column(modifier = Modifier
+        .fillMaxWidth()
+        .height(400.dp),
+        horizontalAlignment =  Alignment.Start,
+        verticalArrangement = Arrangement.Top
+    ) {
+        Spacer(modifier = Modifier.height(0.dp))
         NonMemberPage()
+        Spacer(modifier = Modifier.height(12.dp))
+        NonMemberBanner()
+        Spacer(modifier = Modifier.height(61.dp))
     }
 }
 


### PR DESCRIPTION
**NonMemberScreen**
-----------------------------------
1. **Screen Structure** 
![image](https://github.com/Mnseo/Kusitms_android/assets/100370200/bbfa9059-360b-4199-925f-0ed7d89f000a)


2. **Box 처리**
    
```kotlin
@Composable
fun NonMemberPage() {
    val uriHandler = LocalUriHandler.current
    Box(modifier = Modifier
        .fillMaxWidth()
        .height(160.dp)
        .background(color = KusitmsColorPalette.current.Main500, shape = RoundedCornerShape(16.dp))
        .clickable { uriHandler.openUri("https://www.kusitms.com/") }
    )
    {
    Image(
        painter = painterResource(id = R.drawable.kusitms_non_member_1),
        contentDescription = null,
        contentScale = ContentScale.Crop, // 이미지가 Box를 채우도록 조정
        modifier = Modifier.matchParentSize() // 부모의 크기에 맞춤
    )
``` 

4. **Object** 
     Channel Object 선언으로 반복되는 배너 스크린 배치
  ```kotlin
  /* Channel Object 처리**/  
  data class Channel(
      val imageRes:Int,
      val stringRes: Int,
      val uri: String
      )
  ``` 
  ```kotlin
  /* Channel 반복 디자인 처리**/  
   channels.take(2).forEach { channel ->
            channelItem(
                imageResId = channel.imageRes,
                stringRes = channel.stringRes,
                modifier = Modifier.weight(1f),
                uri = channel.uri
            )
        }
  ``` 
  
  