### PR TITLE
[FEAT] 대댓글 추가 연동 및 BottomSheet 수정

### DIFF
--- a/data/src/main/java/com/kusitms/data/remote/api/KusitmsApi.kt
+++ b/data/src/main/java/com/kusitms/data/remote/api/KusitmsApi.kt
@@ -86,6 +86,13 @@ interface KusitmsApi {
         @Path("commentId") commentId: Int,
     ): BaseResponse<List<CommentPayload>>
 
+    @POST("v1/comment/{noticeId}/{commentId}")
+    suspend fun addNoticeChildComment(
+        @Path("noticeId") noticeId: Int,
+        @Path("commentId") commentId: Int,
+        @Body commentContentRequestBody: CommentContentRequestBody,
+    ): BaseResponse<CommentPayload>
+
     // SignInNonMember
     @FormUrlEncoded
     @POST("v1/member/check/register")

--- a/data/src/main/java/com/kusitms/data/repository/NoticeRepositoryImpl.kt
+++ b/data/src/main/java/com/kusitms/data/repository/NoticeRepositoryImpl.kt
@@ -159,4 +159,25 @@ class NoticeRepositoryImpl @Inject constructor(
             Result.failure(e)
         }
     }
+
+    override suspend fun addNoticeChildComment(
+        noticeId: Int,
+        commentId: Int,
+        commentContentModel: CommentContentModel
+    ): Result<CommentModel> {
+        return try {
+            val response = kusitmsApi.addNoticeChildComment(
+                noticeId = noticeId,
+                commentId = commentId,
+                commentContentRequestBody = commentContentModel.toBody()
+            )
+            if (response.result.code == 200 && response.payload != null) {
+                Result.success(response.payload.toModel())
+            } else {
+                Result.failure(RuntimeException("대댓글 등록 실패: ${response.result.message}"))
+            }
+        } catch (e: Exception){
+            Result.failure(e)
+        }
+    }
 }

--- a/domain/src/main/java/com/kusitms/domain/repository/NoticeRepository.kt
+++ b/domain/src/main/java/com/kusitms/domain/repository/NoticeRepository.kt
@@ -42,4 +42,9 @@ interface NoticeRepository {
         commentId: Int
     ) : Result<List<CommentModel>>
 
+    suspend fun addNoticeChildComment(
+        noticeId: Int,
+        commentId : Int,
+        commentContentModel: CommentContentModel
+    ) : Result<CommentModel>
 }

--- a/domain/src/main/java/com/kusitms/domain/usecase/notice/AddNoticeChildCommentUseCase.kt
+++ b/domain/src/main/java/com/kusitms/domain/usecase/notice/AddNoticeChildCommentUseCase.kt
@@ -1,0 +1,28 @@
+package com.kusitms.domain.usecase.notice
+
+import com.kusitms.domain.model.notice.CommentContentModel
+import com.kusitms.domain.repository.NoticeRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import javax.inject.Inject
+
+class AddNoticeChildCommentUseCase  @Inject constructor(
+    private val noticeRepository: NoticeRepository
+) {
+    operator fun invoke(
+        noticeId : Int,
+        commentId : Int,
+        content : CommentContentModel
+    ): Flow<Unit> = flow {
+        noticeRepository.addNoticeChildComment(
+            noticeId = noticeId,
+            commentId = commentId,
+            commentContentModel = content
+        ).onSuccess {
+            //TODO 타입 변경
+            emit(Unit)
+        }.onFailure {
+            throw it
+        }
+    }
+}

--- a/presentation/src/main/java/com/kusitms/presentation/ui/notice/detail/NoticeDetailBottomSheet.kt
+++ b/presentation/src/main/java/com/kusitms/presentation/ui/notice/detail/NoticeDetailBottomSheet.kt
@@ -18,14 +18,18 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Divider
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -42,13 +46,10 @@ import com.kusitms.domain.model.notice.CommentModel
 import com.kusitms.presentation.common.ui.KusitmsMarginVerticalSpacer
 import com.kusitms.presentation.common.ui.theme.KusitmsColorPalette
 import com.kusitms.presentation.common.ui.theme.KusitmsTypo
-import com.kusitms.presentation.model.notice.CommentUiModel
 import com.kusitms.presentation.ui.ImageVector.icons.KusitmsIcons
 import com.kusitms.presentation.ui.ImageVector.icons.kusitmsicons.Close
 import com.kusitms.presentation.ui.notice.detail.comment.CommentInput
 import com.kusitms.presentation.ui.notice.detail.comment.NoticeComment
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.launch
 
 @Composable
 fun BottomSheetDrawerBar(
@@ -61,10 +62,13 @@ fun BottomSheetDrawerBar(
 }
 
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun NoticeCommentBottom(
     noticeDetailViewModel: NoticeDetailViewModel = hiltViewModel(),
-    targetComment : CommentModel
+    targetComment : CommentModel,
+    onClickChildReport : (NoticeDetailModalState.Report) -> Unit,
+    onClickChildDelete : (NoticeDetailDialogState.CommentDelete) -> Unit
 ){
     val childCommentList by noticeDetailViewModel.childCommentList.collectAsStateWithLifecycle()
 
@@ -74,8 +78,6 @@ fun NoticeCommentBottom(
             targetComment.commentId
         )
     }
-
-
     Column(
         modifier = Modifier
             .fillMaxWidth()
@@ -117,11 +119,15 @@ fun NoticeCommentBottom(
                 NoticeComment(
                     comment = comment,
                     onClickReport = {
-//                        openBottomSheet =
-//                            NoticeDetailModalState.Report(comment, comment.writerId)
+                        onClickChildReport(
+                            NoticeDetailModalState.Report(comment, comment.writerId)
+                        )
                     },
                     onClickDelete = {
-                        //openDialogState = NoticeDetailDialogState.CommentDelete(comment)
+                        onClickChildDelete(
+                            NoticeDetailDialogState.CommentDelete(comment)
+                        )
+
                     },
                     isLast = index == childCommentList.lastIndex
                 )
@@ -133,7 +139,7 @@ fun NoticeCommentBottom(
         CommentInput(
             modifier = Modifier.padding(bottom = 42.dp),
             onClickSend = {
-
+                noticeDetailViewModel.addNoticeChildComment(targetComment.commentId,it)
             }
         )
     }
@@ -269,6 +275,7 @@ fun NoticeCommentReportBottom(
                 boxPadding = PaddingValues(horizontal = 12.5.dp),
                 onClick = {
                     onClick(it)
+                    onDismiss()
                 }
             )
         }

--- a/presentation/src/main/java/com/kusitms/presentation/ui/notice/detail/NoticeDetailScreen.kt
+++ b/presentation/src/main/java/com/kusitms/presentation/ui/notice/detail/NoticeDetailScreen.kt
@@ -84,7 +84,7 @@ sealed class NoticeDetailDialogState() {
 
     object AlreadyReport : NoticeDetailDialogState()
 
-    data class CommentDelete(val comment: CommentModel) : NoticeDetailDialogState()
+    data class CommentDelete(val comment: CommentModel,val isChild : Boolean = false) : NoticeDetailDialogState()
 }
 
 sealed class NoticeDetailModalState() {
@@ -142,6 +142,11 @@ fun NoticeDetailScreen(
     )
 
     var openDialogState by remember { mutableStateOf<NoticeDetailDialogState?>(null) }
+
+    var openBottomSheetInCommentModal by remember { mutableStateOf<NoticeDetailModalState?>(null) }
+    val bottomSheetStateInCommentModal = rememberModalBottomSheetState(
+        skipPartiallyExpanded = true
+    )
 
     LaunchedEffect(key1 = Unit){
         viewModel.snackbarEvent.collect {
@@ -276,7 +281,13 @@ fun NoticeDetailScreen(
                 is NoticeDetailModalState.Comment -> {
                     NoticeCommentBottom(
                         viewModel,
-                        (openBottomSheet as NoticeDetailModalState.Comment).comment
+                        (openBottomSheet as NoticeDetailModalState.Comment).comment,
+                        onClickChildReport = {
+                            openBottomSheetInCommentModal = it
+                        },
+                        onClickChildDelete = {
+                            openDialogState = it
+                        }
                     )
                 }
 
@@ -294,12 +305,49 @@ fun NoticeDetailScreen(
                                     memberId = reportState.memberId
                                 )
                             }
-
+                        },
+                        onDismiss = {
                             openBottomSheet = null
                         }
+                    )
+                }
+            }
+
+
+        }
+    }
+    if (openBottomSheetInCommentModal is NoticeDetailModalState.Report) {
+        ModalBottomSheet(
+            containerColor = KusitmsColorPalette.current.Grey600,
+            dragHandle = { Box(Modifier.height(0.dp)) },
+            onDismissRequest = { openBottomSheetInCommentModal = null },
+            sheetState = bottomSheetStateInCommentModal,
+            modifier = Modifier
+                .fillMaxWidth()
+                .wrapContentHeight()
+        ) {
+            when (openBottomSheetInCommentModal ?: return@ModalBottomSheet) {
+                is NoticeDetailModalState.Report -> {
+                    NoticeCommentReportBottom(
+                        onClick = {
+                            (openBottomSheetInCommentModal as NoticeDetailModalState.Report).let { reportState ->
+                                openDialogState =
+                                    NoticeDetailDialogState.Report(
+                                        comment = reportState.comment,
+                                        report = it,
+                                        memberId = reportState.memberId
+                                    )
+
+                            }
+
+                            openBottomSheetInCommentModal = null
+                        }
                     ) {
-                        openBottomSheet = null
+                        openBottomSheetInCommentModal = null
                     }
+                }
+                else -> {
+
                 }
             }
 

--- a/presentation/src/main/java/com/kusitms/presentation/ui/notice/detail/NoticeDetailViewModel.kt
+++ b/presentation/src/main/java/com/kusitms/presentation/ui/notice/detail/NoticeDetailViewModel.kt
@@ -8,6 +8,7 @@ import com.kusitms.domain.model.notice.CommentModel
 import com.kusitms.domain.model.notice.NoticeModel
 import com.kusitms.domain.model.notice.ReportCommentContentModel
 import com.kusitms.domain.model.report.ReportResult
+import com.kusitms.domain.usecase.notice.AddNoticeChildCommentUseCase
 import com.kusitms.domain.usecase.notice.AddNoticeCommentUseCase
 import com.kusitms.domain.usecase.notice.DeleteCommentUseCase
 import com.kusitms.domain.usecase.notice.GetChildCommentListUseCase
@@ -36,7 +37,8 @@ class NoticeDetailViewModel @Inject constructor(
     private val addNoticeCommentUseCase: AddNoticeCommentUseCase,
     private val deleteCommentUseCase: DeleteCommentUseCase,
     private val reportUseCase: ReportUseCase,
-    private val getChildCommentListUseCase : GetChildCommentListUseCase
+    private val getChildCommentListUseCase : GetChildCommentListUseCase,
+    private val addNoticeChildCommentUseCase : AddNoticeChildCommentUseCase
 ) : ViewModel() {
 
     val noticeId: Int = savedStateHandle.get<Int>(NOTICE_ID_SAVED_STATE_KEY)!!
@@ -109,6 +111,24 @@ class NoticeDetailViewModel @Inject constructor(
                 _snackbarEvent.emit(NoticeDetailSnackbarEvent.NETWORK_ERROR)
             }.collectLatest {
                fetchCommentList()
+                _snackbarEvent.emit(NoticeDetailSnackbarEvent.ADDED_COMMENT)
+            }
+        }
+    }
+
+    fun addNoticeChildComment(
+        commentId: Int,
+        content : String
+    ){
+        viewModelScope.launch {
+            addNoticeChildCommentUseCase(
+                noticeId = noticeId,
+                commentId = commentId,
+                content = CommentContentModel(content)
+            ).catch {
+                _snackbarEvent.emit(NoticeDetailSnackbarEvent.NETWORK_ERROR)
+            }.collectLatest {
+                fetchCommentList()
                 _snackbarEvent.emit(NoticeDetailSnackbarEvent.ADDED_COMMENT)
             }
         }

--- a/presentation/src/main/java/com/kusitms/presentation/ui/notice/detail/comment/NoticeComment.kt
+++ b/presentation/src/main/java/com/kusitms/presentation/ui/notice/detail/comment/NoticeComment.kt
@@ -165,7 +165,7 @@ fun NoticeComment(
             }
 
         }
-        if(!isLast)
+        if(!isLast && !isParentCommentAsReply)
             Divider(
                 modifier = Modifier
                     .fillMaxWidth()


### PR DESCRIPTION
### Issue number and Link
이슈 번호 : #77 


### Summary
대댓글 추가 api 연동 및 Bottom Sheet 수정

*댓글 추가 시 에러가 나네요
{baseurl}/v1/comment/10/26 호출 시
"message":"사용자 상세 정보를 찾을 수 없습니다." 와 에러코드가 나와서
백엔드 개발자에게 문의해야할 것 같습니다.

### PR Type
- [x] Feature
- [ ] Bugfix
- [ ] Code Style Update
- [ ] Refactoring
- [ ] Documentation content change
- [ ] Other


### Other Information



### Common Type
```kotlin
- [UI] : UI 관련 작업
- [FEAT] : 새로운 기능 구현
- [ADD] : feat 이외의 부수적인 코드, 파일, 라이브러리 추가
- [MOD] : 코드 및 내부 파일 수정
- [CHORE] : 버전 코드, 패키지 구조, 함수 및 변수명 변경 등의 작은 작업
- [FIX] : 버그 및 오류 해결
- [DEL] : 불필요한 코드, 파일, 주석 삭제
- [DOCS] : README나 Wiki 등의 문서 작업
- [REFACTOR] : 코드 리팩토링
- [MERGE] : 서로 다른 브랜치 간의 코드 병합
- [COMMENT] : 필요한 주석 추가 및 변경
- [SETTING] : 프로젝트 기초 세팅 관련 작업
```

### branch 
- 모든 글자는 소문자로 작성한다.

```
feature/{type}-{작업 내용}

ex)
feature/feat-main-view
feature/add-font-res
```
